### PR TITLE
fixed some warnings, removed trailing spaces

### DIFF
--- a/examples/DisplayLamps/DisplayLamps.ino
+++ b/examples/DisplayLamps/DisplayLamps.ino
@@ -13,9 +13,9 @@
 #include "Dimmer.h"
 
 // Set 3 dimerable lights in ramp mode (smooth transitions) with speed 100 at pins 3,5 and 6
-Dimmer lamp1(3, RAMP_MODE, 100, 50, ON);
-Dimmer lamp2(5, RAMP_MODE, 100, 50, OFF);
-Dimmer lamp3(6, RAMP_MODE, 100, 50, OFF);
+Dimmer lamp1(3, RAMP_MODE, 50, ON, 100);
+Dimmer lamp2(5, RAMP_MODE, 50, OFF, 100);
+Dimmer lamp3(6, RAMP_MODE, 50, OFF, 100);
 
 // Light powers animation
 #define p1  20

--- a/examples/RandomLamps/RandomLamps.ino
+++ b/examples/RandomLamps/RandomLamps.ino
@@ -12,9 +12,9 @@
 
 #include "Dimmer.h"
 
-Dimmer lamp1(3, NORMAL_MODE, 100, 50, ON);
-Dimmer lamp2(5, RAMP_MODE, 100, 50, OFF);
-Dimmer lamp3(6, RAMP_MODE, 100, 50, OFF);
+Dimmer lamp1(3, NORMAL_MODE, 50, ON, 100);
+Dimmer lamp2(5, RAMP_MODE, 50, OFF, 100);
+Dimmer lamp3(6, RAMP_MODE, 50, OFF, 100);
 
 int value;
 

--- a/examples/WaveLamps/WaveLamps.ino
+++ b/examples/WaveLamps/WaveLamps.ino
@@ -13,17 +13,17 @@
 #include "Dimmer.h"
 
 //store dimm lights in array
-Dimmer dimm[] = { Dimmer(3, RAMP_MODE, 100, 50, ON), 
-                  Dimmer(5, RAMP_MODE, 100, 50, OFF),
-                  Dimmer(6, RAMP_MODE, 100, 50, OFF) 
+Dimmer dimm[] = { Dimmer(3, RAMP_MODE, 50, ON, 100),
+                  Dimmer(5, RAMP_MODE, 50, OFF, 100),
+                  Dimmer(6, RAMP_MODE, 50, OFF, 100)
                 };
 #define p1  20
 #define p2  60
 
-byte pot[6][3] = {  {p2,  0, 0 }, 
+byte pot[6][3] = {  {p2,  0, 0 },
                     {p1, p1, 0 },
-                    {0 , p2, 0 }, 
-                    {0 , p1, p1}, 
+                    {0 , p2, 0 },
+                    {0 , p1, p1},
                     {0 ,  0, p2},
                     {p1,  0, p1}
                   };

--- a/src/Dimmer.cpp
+++ b/src/Dimmer.cpp
@@ -1,6 +1,6 @@
 /*
  This is the Dimmer library to control AC loads, including dimmable lamps.
- 
+
  Version 2.0 - Multi-instance objects.
 
  Copyright (c) 2015 Circuitar
@@ -12,16 +12,16 @@
 
 // Time table to set triacs
 static int triacTime[] ={
-  147, 142, 139, 136, 133, 131, 129, 127, 125, 124, 
-  122, 121, 119, 118, 116, 115, 114, 113, 112, 111, 
-  110, 108, 107, 106, 105, 104, 103, 102, 102, 101, 
-  100,  99,  98,  97,  96,  95,  94,  93,  93,  92, 
-   91,  90,  89,  88,  88,  87,  86,  85,  84,  83, 
-   83,  82,  81,  80,  79,  78,  77,  77,  76,  75, 
-   74,  73,  72,  71,  71,  70,  69,  68,  67,  66, 
-   65,  64,  63,  62,  61,  60,  59,  58,  57,  56, 
-   55,  54,  53,  51,  50,  49,  48,  46,  45,  43, 
-   42,  40,  38,  36,  34,  31,  28,  24,  19,  0 
+  147, 142, 139, 136, 133, 131, 129, 127, 125, 124,
+  122, 121, 119, 118, 116, 115, 114, 113, 112, 111,
+  110, 108, 107, 106, 105, 104, 103, 102, 102, 101,
+  100,  99,  98,  97,  96,  95,  94,  93,  93,  92,
+   91,  90,  89,  88,  88,  87,  86,  85,  84,  83,
+   83,  82,  81,  80,  79,  78,  77,  77,  76,  75,
+   74,  73,  72,  71,  71,  70,  69,  68,  67,  66,
+   65,  64,  63,  62,  61,  60,  59,  58,  57,  56,
+   55,  54,  53,  51,  50,  49,  48,  46,  45,  43,
+   42,  40,  38,  36,  34,  31,  28,  24,  19,  0
 };
 
 static Dimmer* dimmmers[MAX_TRIAC]; //  Pointers to all registered dimmer objects
@@ -44,44 +44,46 @@ void callTriac(){
 
 // Timer2 compare interruption
 ISR(TIMER2_COMPA_vect) {
-  callTriac();    
+  callTriac();
 }
 
 // Class Constructor
-Dimmer::Dimmer(uint8_t triacPin, uint8_t mode, uint8_t value, bool state, uint16_t resolution){
+Dimmer::Dimmer(uint8_t triacPin, uint8_t mode, uint8_t value, bool state, uint16_t resolution) :
+        triacPin(triacPin),
+        operationMode(mode),
+        lampValue(value),
+        lampState(state),
+        countResolution(resolution),
+        pulses(0),
+        pulseCount(0),
+        msCounter(0),
+        rampCounter(0)
+{
   if (dimmerCount < MAX_TRIAC){
     if (mode == RAMP_MODE){
-      this->lampValue = value;
       this->lampValueRamp = 0;
     }
     else{
       this->lampValueRamp = value;
     }
 
-    this->triacPin = triacPin;
-    this->operationMode = mode;
-    this->lampState = state;
-    this->countResolution = resolution;
-    this->msCounter = 0;
-    this->rampCounter = 0;
-
     // Register dimmer objects
     dimmmers[dimmerCount++] = this;
   }
 }
 
-bool Dimmer::begin(){
-  pinMode(triacPin, OUTPUT);  
+void Dimmer::begin(){
+  pinMode(triacPin, OUTPUT);
 
   if(!started){
     pinMode(zeroCrossPin, INPUT);
     attachInterrupt(zeroCrossInt, callZeroCross, RISING);
-    started = true; 
+    started = true;
   }
 
   if(operationMode != COUNT_MODE){
     // Setup Timer2 to fire every 50us
-    TCCR2A = 0x02;    // CTC mode 
+    TCCR2A = 0x02;    // CTC mode
     TCCR2B = 0x02;    // prescaler=8
     TIMSK2 = 0x02;    // Timer2 Compare Match Interrupt Enable
     OCR2A = 99;       // Compare value
@@ -132,17 +134,17 @@ void Dimmer::set(uint8_t value, bool state){
 void Dimmer::zeroCross(){
   if (operationMode == COUNT_MODE) {
     if (pulses >= 0x8000000000000000 && pulseCount > 0){ // Check the MSB bit
-      pulseCount--; 
+      pulseCount--;
     }
 
     pulses = pulses << 1;
-    
+
     if (lampValueRamp > pulseCount * 1.5625){
       digitalWrite(triacPin, HIGH);
       //if (pulseCount < 32){ // check upper boundary
         pulses++;
         pulseCount++;
-      //}  
+      //}
     } else {
       digitalWrite(triacPin, LOW);
     }
@@ -151,14 +153,14 @@ void Dimmer::zeroCross(){
     // Clear counter
     msCounter=0;
     // Turn-off triac
-    digitalWrite(triacPin, LOW);   
+    digitalWrite(triacPin, LOW);
   }
 }
 
 void Dimmer::triac(){
   if (operationMode != COUNT_MODE) {
     msCounter++;
-    
+
     //With ramp mode
     if (operationMode == RAMP_MODE){
       rampCounter++;
@@ -172,7 +174,7 @@ void Dimmer::triac(){
         }
       }
     }
-  
+
     if(lampValueRamp > 0 && lampState){
       if(triacTime[lampValueRamp-1] <= msCounter){
         digitalWrite(triacPin, HIGH);

--- a/src/Dimmer.h
+++ b/src/Dimmer.h
@@ -73,7 +73,7 @@ class Dimmer
      *
      * Initializes ZeroCross and Timer 2 interrupts. Set the light according to initial settings.
      */
-    bool begin();
+    void begin();
 
     /**
      * Turns the light OFF.

--- a/src/Dimmer.h
+++ b/src/Dimmer.h
@@ -21,7 +21,7 @@
  * NanoShield_zeroCross pin settings.
  *
  * @param zeroCrossPin  Change this parameter to the pin your zero cross is attached.
- * @param zeroCrossInt  Change this parameter to the interruption correspondent to the pin of the zero cross. 
+ * @param zeroCrossInt  Change this parameter to the interruption correspondent to the pin of the zero cross.
  * @see https://www.arduino.cc/en/Reference/attachInterrupt for more information.
  */
 #define zeroCrossPin    2
@@ -44,14 +44,14 @@
  * A ZeroCross Nanoshield or similar module to dimm AC lights.
  */
 class Dimmer
-{    
+{
   public:
     /**
      * Constructor.
      *
      * Creates an object to access one Triac Nanoshield.
      * @param triacPin  pin select matching the jumper on the board. (D3, D5, etc)
-     * @param mode  operation mode to crontrol the light. 
+     * @param mode  operation mode to crontrol the light.
      *          Possible modes:
      *          NORMAL_MODE: Uses timer to apply only a percentage of the AC power to the light.
      *          RAMP_MODE: Same as in normal mode, but it applies a ramp effect to the light.
@@ -62,10 +62,10 @@ class Dimmer
      * @param resolution  Applied only in RAMP_MODE
      *          Controlls the speed of the ramp when changing values.
      *          If resolution is 200 the lamp goes from 0% to 100% in one second.
-     *          Maximum value: 65535. Default value is 300. 
-     *          
+     *          Maximum value: 65535. Default value is 300.
+     *
      * @see   begin()
-     */ 
+     */
     Dimmer(uint8_t triacPin, uint8_t mode = NORMAL_MODE, uint8_t value=50, bool state = ON, uint16_t resolution = 300);
 
     /**
@@ -76,17 +76,17 @@ class Dimmer
     bool begin();
 
     /**
-     * Turns the light OFF. 
+     * Turns the light OFF.
      */
     void off();
 
     /**
-     * Turns the light ON. 
+     * Turns the light ON.
      */
     void on();
 
     /**
-     * Toggles the light state. 
+     * Toggles the light state.
      */
     void toggle();
 
@@ -118,14 +118,14 @@ class Dimmer
     void set(uint8_t value, bool state);
 
   private:
-    uint8_t operationMode;
-    uint16_t countResolution;
-    uint64_t pulses = 0;
-    uint8_t pulseCount = 0;
     uint8_t triacPin;
+    uint8_t operationMode;
     uint8_t lampValue;
     uint8_t lampValueRamp;
     bool lampState;
+    uint16_t countResolution;
+    uint64_t pulses;
+    uint8_t pulseCount;
     uint8_t msCounter;
     uint16_t rampCounter;
 


### PR DESCRIPTION
Just a quick fix for the warnings (i.e. no return statement in function returning non-void, non-static data member initializers only available with -std=c++11 or -std=gnu++11). Removed trailing spaces. The initializer list order matters - so had to reorder in header.

Fixed the examples to match the constructor of the class.